### PR TITLE
Re-encode raw signature

### DIFF
--- a/utils/mina_ledger_wallet.py
+++ b/utils/mina_ledger_wallet.py
@@ -723,6 +723,21 @@ def ledger_send_apdu(apdu_hex):
 def ledger_crypto_tests():
     return ledger_send_apdu("e004000000")
 
+
+def re_encode_raw_signature(signature):
+
+    def shuffle_bytes(hex):
+        return "".join(reversed([hex[i:i+2] for i in range(0, len(hex), 2)]))
+
+    if len(signature) != 128:
+        raise Exception("Invalid raw signature input")
+
+    field = signature[0:64]
+    scalar = signature[64:]
+
+    return shuffle_bytes(field) + shuffle_bytes(scalar)
+
+
 def ledger_get_address(account):
     # Create APDU message.
     # CLA 0xe0 CLA
@@ -1209,7 +1224,8 @@ if __name__ == "__main__":
                 "mint_tokens": null
             }""")
 
-            transaction_json["signature"] = signature
+            # Re-encode the signature such that it can be broadcast via sendPayment mutation
+            transaction_json["signature"] = re_encode_raw_signature(signature)
             if args.operation == "send-payment":
                 transaction_json["payment"] = transaction_data
             elif args.operation == "delegate":

--- a/utils/mina_ledger_wallet.py
+++ b/utils/mina_ledger_wallet.py
@@ -1224,7 +1224,7 @@ if __name__ == "__main__":
                 "mint_tokens": null
             }""")
 
-            # Re-encode the signature such that it can be broadcast via sendPayment mutation
+            # Re-encode the signature such that it can be broadcast via GraphQL > 1.3.0alpha3
             transaction_json["signature"] = re_encode_raw_signature(signature)
             if args.operation == "send-payment":
                 transaction_json["payment"] = transaction_data


### PR DESCRIPTION
The format of the signature to broadcast via GraphQL has changed (daemon version > 1.3.0alpha3). Previously the output of this tool could be used to broadcast via GraphQL but this now results in an invalid signature error as the encoding of the signatures has changed.

This implements the fix outlined in JS by @bkase to re-encode the signatures to match the updated format. Tested locally by running `./utils/mina_ledger_wallet.py send-payment ...` and then broadcasting the resulting output via GraphQL `sendPayment` and with the `sendRosettaTransaction` mutation. 

Original JS:

```js
function reEncodeRawSignature(rawSignature) {
  function shuffleBytes(hex) {
    let bytes = hex.match(/.{2}/g);
    bytes.reverse();
    return bytes.join("");
  }

  if (rawSignature.length !== 128) {
    throw 'Invalid raw signature input'
  }
  const field = rawSignature.substring(0,64);
  const scalar = rawSignature.substring(64);
  return shuffleBytes(field) + shuffleBytes(scalar)
}
```